### PR TITLE
Replace all occurrences of InVisionApp to confluentinc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ For _full_ examples, look through the [examples dir](examples/)
 
 ```golang
 import (
-	health "github.com/InVisionApp/go-health/v2"
-	"github.com/InVisionApp/go-health/v2/checkers"
-	"github.com/InVisionApp/go-health/v2/handlers"
+	health "github.com/confluentinc/go-health/v2"
+	"github.com/confluentinc/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/handlers"
 )
 
 // Create a new health instance

--- a/checkers/reachable_test.go
+++ b/checkers/reachable_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/InVisionApp/go-health/v2/checkers"
-	"github.com/InVisionApp/go-health/v2/fakes"
-	"github.com/InVisionApp/go-health/v2/fakes/netfakes"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/confluentinc/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/fakes"
+	"github.com/confluentinc/go-health/v2/fakes/netfakes"
 )
 
 func TestReachableSuccessUsingDefaults(t *testing.T) {

--- a/examples/custom-checker-server/custom-checker-server.go
+++ b/examples/custom-checker-server/custom-checker-server.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/InVisionApp/go-health/v2"
-	"github.com/InVisionApp/go-health/v2/handlers"
+	"github.com/confluentinc/go-health/v2"
+	"github.com/confluentinc/go-health/v2/handlers"
 )
 
 type customCheck struct{}

--- a/examples/simple-http-server/simple-http-server.go
+++ b/examples/simple-http-server/simple-http-server.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/InVisionApp/go-health/v2"
-	"github.com/InVisionApp/go-health/v2/checkers"
-	"github.com/InVisionApp/go-health/v2/handlers"
+	"github.com/confluentinc/go-health/v2"
+	"github.com/confluentinc/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/handlers"
 )
 
 func main() {

--- a/examples/status-listener/service/service.go
+++ b/examples/status-listener/service/service.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/InVisionApp/go-health/v2"
-	"github.com/InVisionApp/go-health/v2/checkers"
-	"github.com/InVisionApp/go-health/v2/handlers"
+	"github.com/confluentinc/go-health/v2"
+	"github.com/confluentinc/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/handlers"
 )
 
 var svcLogger *log.Logger

--- a/fakes/ireachabledatadogincrementer.go
+++ b/fakes/ireachabledatadogincrementer.go
@@ -4,7 +4,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/checkers"
 )
 
 type FakeReachableDatadogIncrementer struct {

--- a/fakes/isqlexecer.go
+++ b/fakes/isqlexecer.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"sync"
 
-	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/checkers"
 )
 
 type FakeSQLExecer struct {

--- a/fakes/isqlpinger.go
+++ b/fakes/isqlpinger.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/checkers"
 )
 
 type FakeSQLPinger struct {

--- a/fakes/isqlqueryer.go
+++ b/fakes/isqlqueryer.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"sync"
 
-	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/confluentinc/go-health/v2/checkers"
 )
 
 type FakeSQLQueryer struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/InVisionApp/go-health/v2
+module github.com/confluentinc/go-health/v2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -9,9 +9,9 @@ it at a handler func.
 
 ```golang
 import (
-    "github.com/InVisionApp/go-health/v2"
-    "github.com/InVisionApp/go-health/v2/checkers"
-    "github.com/InVisionApp/go-health/v2/handlers"
+    "github.com/confluentinc/go-health/v2"
+    "github.com/confluentinc/go-health/v2/checkers"
+    "github.com/confluentinc/go-health/v2/handlers"
 )
 
 // create and configure a new health instance

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/InVisionApp/go-health/v2"
+	"github.com/confluentinc/go-health/v2"
 )
 
 type jsonStatus struct {
@@ -20,7 +20,7 @@ type mutexMap struct {
 }
 
 // NewBasicHandlerFunc will return an `http.HandlerFunc` that will write `ok`
-// string + `http.StatusOK` to `rw`` if `h.Failed()` returns `false`;
+// string + `http.StatusOK` to `rw` if `h.Failed()` returns `false`;
 // returns `error` + `http.StatusInternalServerError` if `h.Failed()` returns `true`.
 func NewBasicHandlerFunc(h health.IHealth) http.HandlerFunc {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -39,7 +39,7 @@ func NewBasicHandlerFunc(h health.IHealth) http.HandlerFunc {
 
 // NewJSONHandlerFunc will return an `http.HandlerFunc` that will marshal and
 // write the contents of `h.StateMapInterface()` to `rw` and set status code to
-//  `http.StatusOK` if `h.Failed()` is `false` OR set status code to
+// `http.StatusOK` if `h.Failed()` is `false` OR set status code to
 // `http.StatusInternalServerError` if `h.Failed` is `true`.
 // It also accepts a set of optional custom fields to be added to the final JSON body
 func NewJSONHandlerFunc(h health.IHealth, custom map[string]interface{}) http.HandlerFunc {

--- a/health_shared_test.go
+++ b/health_shared_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/InVisionApp/go-health/v2/fakes"
 	"github.com/InVisionApp/go-logger"
+
+	"github.com/confluentinc/go-health/v2/fakes"
 )
 
 func setupRunners(cfgs []*Config, logger log.Logger) (*Health, []*Config, error) {

--- a/health_test.go
+++ b/health_test.go
@@ -8,9 +8,10 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/InVisionApp/go-health/v2/fakes"
 	"github.com/InVisionApp/go-logger"
 	"github.com/InVisionApp/go-logger/shims/testlog"
+
+	"github.com/confluentinc/go-health/v2/fakes"
 )
 
 var (


### PR DESCRIPTION
Fix the go module path so we can import this lib instead of the archived one https://github.com/InVisionApp/go-health.

Ran unit tests
```
> make test/unit
go test -cover github.com/confluentinc/go-health/v2 github.com/confluentinc/go-health/v2/checkers github.com/confluentinc/go-health/v2/checkers/disk github.com/confluentinc/go-health/v2/checkers/memcache github.com/confluentinc/go-health/v2/checkers/mongo github.com/confluentinc/go-health/v2/checkers/redis github.com/confluentinc/go-health/v2/examples/custom-checker-server github.com/confluentinc/go-health/v2/examples/simple-http-server github.com/confluentinc/go-health/v2/examples/status-listener/dependency github.com/confluentinc/go-health/v2/examples/status-listener/service github.com/confluentinc/go-health/v2/handlers
# github.com/shirou/gopsutil/disk
In file included from /Users/augustwang/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/disk/disk_darwin_cgo.go:24:
/Users/augustwang/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/disk/disk_darwin.h:19:38: warning: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:133:19: note: 'kIOMasterPortDefault' has been explicitly marked deprecated here
ok      github.com/confluentinc/go-health/v2    0.776s  coverage: 96.9% of statements
ok      github.com/confluentinc/go-health/v2/checkers   0.740s  coverage: 100.0% of statements
ok      github.com/confluentinc/go-health/v2/checkers/disk      0.461s  coverage: 100.0% of statements
ok      github.com/confluentinc/go-health/v2/checkers/memcache  0.871s  coverage: 95.0% of statements
        github.com/confluentinc/go-health/v2/checkers/mongo             coverage: 0.0% of statements
ok      github.com/confluentinc/go-health/v2/checkers/redis     0.792s  coverage: 100.0% of statements
        github.com/confluentinc/go-health/v2/examples/custom-checker-server             coverage: 0.0% of statements
        github.com/confluentinc/go-health/v2/examples/simple-http-server                coverage: 0.0% of statements
        github.com/confluentinc/go-health/v2/examples/status-listener/dependency                coverage: 0.0% of statements
        github.com/confluentinc/go-health/v2/examples/status-listener/service           coverage: 0.0% of statements
        github.com/confluentinc/go-health/v2/handlers           coverage: 0.0% of statements

```