### PR TITLE
MINOR: Give callbacks a copy of the state struct

### DIFF
--- a/health.go
+++ b/health.go
@@ -343,7 +343,9 @@ func (h *Health) handleStatusListener(stateEntry *State) {
 		if !prevState.isFailure() {
 			// new failure: previous state was ok
 			if h.StatusListener != nil {
-				go h.StatusListener.HealthCheckFailed(stateEntry)
+				// copy the stateEntry so the callbacks can use it without risk of it being modified
+				copyEntry := *stateEntry
+				go h.StatusListener.HealthCheckFailed(&copyEntry)
 			}
 
 			stateEntry.TimeOfFirstFailure = time.Now()
@@ -357,7 +359,9 @@ func (h *Health) handleStatusListener(stateEntry *State) {
 		failureSeconds := time.Now().Sub(prevState.TimeOfFirstFailure).Seconds()
 
 		if h.StatusListener != nil {
-			go h.StatusListener.HealthCheckRecovered(stateEntry, prevState.ContiguousFailures, failureSeconds)
+			// copy the stateEntry so the callbacks can use it without risk of it being modified
+			copyEntry := *stateEntry
+			go h.StatusListener.HealthCheckRecovered(&copyEntry, prevState.ContiguousFailures, failureSeconds)
 		}
 	}
 }


### PR DESCRIPTION
## What

Give callbacks a copy of the state struct

## Why

If we do this then we can prevent race conditions when the callback reads the struct fields. Even if they update the struct fields later (I don't think they should), we really would have had some race conditions then and there's no guarantee when our write would apply. 

This does prevent callbacks from editing the state struct. That was arguably a bug since it inherently creates a race condition. People could do things like edit the state name or last failed time, etc. which seems something that the main go-health struct should control. 