### PR TITLE
feat: add Configs() to IHealth, lock configs in Start/AddCheck

### DIFF
--- a/health.go
+++ b/health.go
@@ -38,6 +38,7 @@ type IHealth interface {
 	Stop() error
 	State() (map[string]State, bool, error)
 	Failed() bool
+	Configs() []*Config
 }
 
 // ICheckable is an interface implemented by a number of bundled checkers such
@@ -125,22 +126,24 @@ type Health struct {
 	// StatusListener will report failures and recoveries
 	StatusListener IStatusListener
 
-	active     *sBool // indicates whether the healthcheck is actively running
-	configs    []*Config
-	states     map[string]State
-	statesLock sync.Mutex
-	runners    map[string]chan struct{} // contains map of active runners w/ a stop channel
+	active      *sBool // indicates whether the healthcheck is actively running
+	configs     []*Config
+	configsLock sync.Mutex
+	states      map[string]State
+	statesLock  sync.Mutex
+	runners     map[string]chan struct{} // contains map of active runners w/ a stop channel
 }
 
 // New returns a new instance of the Health struct.
 func New() *Health {
 	return &Health{
-		Logger:     log.NewSimple(),
-		configs:    make([]*Config, 0),
-		states:     make(map[string]State, 0),
-		runners:    make(map[string]chan struct{}, 0),
-		active:     newBool(),
-		statesLock: sync.Mutex{},
+		Logger:      log.NewSimple(),
+		configs:     make([]*Config, 0),
+		states:      make(map[string]State, 0),
+		runners:     make(map[string]chan struct{}, 0),
+		active:      newBool(),
+		statesLock:  sync.Mutex{},
+		configsLock: sync.Mutex{},
 	}
 }
 
@@ -152,39 +155,61 @@ func (h *Health) DisableLogging() {
 // AddChecks is used for adding multiple check definitions at once (as opposed
 // to adding them sequentially via "AddCheck()").
 func (h *Health) AddChecks(cfgs []*Config) error {
+	h.configsLock.Lock()
+	defer h.configsLock.Unlock()
 	if h.active.val() {
 		return ErrNoAddCfgWhenActive
 	}
-
 	h.configs = append(h.configs, cfgs...)
-
 	return nil
 }
 
 // AddCheck is used for adding a single check definition to the current health
 // instance.
 func (h *Health) AddCheck(cfg *Config) error {
+	h.configsLock.Lock()
+	defer h.configsLock.Unlock()
 	if h.active.val() {
 		return ErrNoAddCfgWhenActive
 	}
-
 	h.configs = append(h.configs, cfg)
 	return nil
+}
+
+// Configs returns a snapshot of all registered check configurations. The
+// returned slice is a copy — appending to it or reordering it does not affect
+// the Health instance. The *Config pointers are shared with internal state;
+// callers must not mutate fields on the returned configs.
+func (h *Health) Configs() []*Config {
+	h.configsLock.Lock()
+	defer h.configsLock.Unlock()
+	out := make([]*Config, len(h.configs))
+	copy(out, h.configs)
+	return out
 }
 
 // Start will start all of the defined health checks. Each of the checks run in
 // their own goroutines (as "time.Ticker").
 func (h *Health) Start() error {
+	h.configsLock.Lock()
 	if h.active.val() {
+		h.configsLock.Unlock()
 		return ErrAlreadyRunning
 	}
+	// Snapshot configs under the lock so a concurrent AddCheck/AddChecks can't
+	// race with the launch loop below. The active flag flips inside the same
+	// critical section, which serializes Start against any further AddCheck/
+	// AddChecks attempts.
+	configs := make([]*Config, len(h.configs))
+	copy(configs, h.configs)
 
 	// if there are no check configs, this is a noop
-	if len(h.configs) < 1 {
+	if len(configs) < 1 {
+		h.configsLock.Unlock()
 		return nil
 	}
 
-	for _, c := range h.configs {
+	for _, c := range configs {
 		h.Logger.WithFields(log.Fields{"name": c.Name}).Debug("Starting checker")
 		ticker := time.NewTicker(c.Interval)
 		stop := make(chan struct{})
@@ -196,6 +221,7 @@ func (h *Health) Start() error {
 
 	// Checkers are now actively running
 	h.active.setTrue()
+	h.configsLock.Unlock()
 
 	return nil
 }

--- a/health.go
+++ b/health.go
@@ -192,24 +192,17 @@ func (h *Health) Configs() []*Config {
 // their own goroutines (as "time.Ticker").
 func (h *Health) Start() error {
 	h.configsLock.Lock()
+	defer h.configsLock.Unlock()
 	if h.active.val() {
-		h.configsLock.Unlock()
 		return ErrAlreadyRunning
 	}
-	// Snapshot configs under the lock so a concurrent AddCheck/AddChecks can't
-	// race with the launch loop below. The active flag flips inside the same
-	// critical section, which serializes Start against any further AddCheck/
-	// AddChecks attempts.
-	configs := make([]*Config, len(h.configs))
-	copy(configs, h.configs)
 
 	// if there are no check configs, this is a noop
-	if len(configs) < 1 {
-		h.configsLock.Unlock()
+	if len(h.configs) < 1 {
 		return nil
 	}
 
-	for _, c := range configs {
+	for _, c := range h.configs {
 		h.Logger.WithFields(log.Fields{"name": c.Name}).Debug("Starting checker")
 		ticker := time.NewTicker(c.Interval)
 		stop := make(chan struct{})
@@ -221,7 +214,6 @@ func (h *Health) Start() error {
 
 	// Checkers are now actively running
 	h.active.setTrue()
-	h.configsLock.Unlock()
 
 	return nil
 }

--- a/health_test.go
+++ b/health_test.go
@@ -714,3 +714,43 @@ func TestStatusListenerOnRecover(t *testing.T) {
 		Expect(string(testLogger.Bytes())).To(ContainSubstring(testStr))
 	})
 }
+
+func TestConfigs(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("Returns empty slice when nothing has been added", func(t *testing.T) {
+		h := setupNewTestHealth()
+		Expect(h.Configs()).To(BeEmpty())
+	})
+
+	t.Run("Returns registered configs in registration order", func(t *testing.T) {
+		h := setupNewTestHealth()
+		cfgs := []*Config{
+			{Name: "foo", Checker: &fakes.FakeICheckable{}, Interval: testCheckInterval},
+			{Name: "bar", Checker: &fakes.FakeICheckable{}, Interval: testCheckInterval},
+		}
+		Expect(h.AddChecks(cfgs)).To(Succeed())
+
+		got := h.Configs()
+		Expect(got).To(HaveLen(2))
+		Expect(got[0].Name).To(Equal("foo"))
+		Expect(got[1].Name).To(Equal("bar"))
+	})
+
+	t.Run("Returned slice is a copy", func(t *testing.T) {
+		h := setupNewTestHealth()
+		Expect(h.AddCheck(&Config{Name: "foo", Checker: &fakes.FakeICheckable{}, Interval: testCheckInterval})).To(Succeed())
+
+		got := h.Configs()
+		Expect(got).To(HaveLen(1))
+
+		// Mutating the returned slice (append + reorder) must not affect internal state
+		got = append(got, &Config{Name: "bogus"})
+		got[0] = &Config{Name: "replaced"}
+
+		again := h.Configs()
+		Expect(again).To(HaveLen(1))
+		Expect(again[0].Name).To(Equal("foo"))
+	})
+}
+


### PR DESCRIPTION
## Summary

Adds a read-only introspection method to `IHealth`:

- **`Configs() []*Config`** — snapshot of registered check configurations.

## Motivation

Callers that wire `go-health` into a larger application lifecycle need a startup gate: "don't declare the service ready until every check has had a chance to run at least once." Today there's no clean way to ask that question — callers have to keep a parallel registry of "what did I register" and reconcile it against `State()`.

The immediate downstream is `service-runtime-go`'s healthcheck module, which currently maintains a parallel registry (an `fx` value group plus an internal `expectedChecks` box) just to answer "are we done warming up?" With `Configs()`, the gate becomes a small loop iterating `Configs()` against `State()`, and the bookkeeping disappears.

(An earlier version of this PR also added a composite `AllRan() (bool, []string)` method. Removed per @CTrando's feedback — keeps the interface minimal. SRG's gate inlines the loop using `Configs()` + `State()`.)

## Thread safety

The internal `configs` slice was previously unguarded (mutations gated only by `h.active`). To make the new readers safe to call concurrently with `AddCheck`/`AddChecks` and with running checkers, a dedicated `configsLock` is added.

- `AddCheck` / `AddChecks` take `configsLock` *before* the `h.active.val()` check so the gate and the slice mutation are atomic against `Start`.
- `Start()` holds `configsLock` (via `defer`) through the gate, the launch loop, and the `active` flip. Because `AddCheck`/`AddChecks` acquire the same lock before checking `active`, no append can interleave with `Start`'s launch — either `AddCheck` sees `active==true` and rejects, or it appended before `Start` gated and gets included in `Start`'s loop.
- `Configs()` acquires `configsLock` for the duration of its copy, so it never observes a torn slice header.

## Test plan

- [x] `TestConfigs` — empty, registered, returned slice is a copy
- [x] `go test -race` clean on `TestConfigs`, `TestAddCheck`, `TestAddChecks` (TestStart/TestStartRunner have a pre-existing test-side race on `h.states` direct access — unaffected by this PR)
- [x] Full unit suite passes
- [x] Audited `org:confluentinc` for `health.IHealth` callers — only `service-runtime-go` consumes the type and only its own `MockIHealth` implements it (regenerated in [service-runtime-go#1096](https://github.com/confluentinc/service-runtime-go/pull/1096)). Adding a method to `IHealth` is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
